### PR TITLE
issue #17 corrections (tidesdb-rs v0.6.1) PATCH

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tidesdb"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
-authors = ["TidesDB <contact@tidesdb.com>"]
+authors = ["TidesDB <hello@tidesdb.com>"]
 description = "Safe Rust bindings for TidesDB - A high-performance embedded key-value storage engine"
 license = "MPL-2.0"
 repository = "https://github.com/tidesdb/tidesdb-rs"

--- a/src/db.rs
+++ b/src/db.rs
@@ -352,10 +352,10 @@ impl TidesDB {
                 if !name_ptr.is_null() {
                     let name = CStr::from_ptr(name_ptr).to_string_lossy().into_owned();
                     result_names.push(name);
-                    libc::free(name_ptr as *mut libc::c_void);
+                    ffi::tidesdb_free(name_ptr as *mut c_void);
                 }
             }
-            libc::free(names as *mut libc::c_void);
+            ffi::tidesdb_free(names as *mut c_void);
         }
 
         Ok(result_names)

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -122,7 +122,7 @@ impl Transaction {
         let value = unsafe {
             let slice = std::slice::from_raw_parts(value_ptr, value_len);
             let vec = slice.to_vec();
-            libc::free(value_ptr as *mut libc::c_void);
+            ffi::tidesdb_free(value_ptr as *mut std::ffi::c_void);
             vec
         };
 


### PR DESCRIPTION
corrected allocator mismatch bug in tidesdb-rs by replacing all hardcoded libc::free calls with ffi::tidesdb_free in transaction get and list_column_families, ensuring c-allocated buffers are freed through the configured allocator instead of the system allocator. this resolves cross-allocator issues for embedders like redis modules that use custom memory allocators via init_with_allocator. bump version to 0.6.1 and update contact email.