### PR TITLE
Add vendored TidesDB source crates

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,6 +32,26 @@ jobs:
           repository: tidesdb/tidesdb-rs
           path: tidesdb-rs
 
+      - name: Prepare local source crate patches
+        shell: bash
+        working-directory: tidesdb-rs
+        run: |
+          PYTHON=python3
+          if ! command -v python3 >/dev/null 2>&1; then
+            PYTHON=python
+          fi
+          "$PYTHON" -m venv .cargo/sync-venv
+          VENV_PYTHON=.cargo/sync-venv/bin/python
+          if [ ! -x "$VENV_PYTHON" ]; then
+            VENV_PYTHON=.cargo/sync-venv/Scripts/python.exe
+          fi
+          "$VENV_PYTHON" -m pip install tomlkit requests InquirerPy
+          "$VENV_PYTHON" scripts/sync-versions.py \
+            --prepare-local-patches .cargo/tidesdb-src \
+            --write-cargo-patch-config .cargo/config.toml \
+            --versions current \
+            --yes
+
       - name: Checkout tidesdb repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_from_source.yml
+++ b/.github/workflows/build_from_source.yml
@@ -29,6 +29,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Prepare local source crate patches
+        shell: bash
+        run: |
+          PYTHON=python3
+          if ! command -v python3 >/dev/null 2>&1; then
+            PYTHON=python
+          fi
+          "$PYTHON" -m venv .cargo/sync-venv
+          VENV_PYTHON=.cargo/sync-venv/bin/python
+          if [ ! -x "$VENV_PYTHON" ]; then
+            VENV_PYTHON=.cargo/sync-venv/Scripts/python.exe
+          fi
+          "$VENV_PYTHON" -m pip install tomlkit requests InquirerPy
+          "$VENV_PYTHON" scripts/sync-versions.py \
+            --prepare-local-patches .cargo/tidesdb-src \
+            --write-cargo-patch-config .cargo/config.toml \
+            --versions current \
+            --yes
+
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -150,6 +169,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Prepare local source crate patches
+        shell: bash
+        run: |
+          PYTHON=python3
+          if ! command -v python3 >/dev/null 2>&1; then
+            PYTHON=python
+          fi
+          "$PYTHON" -m venv .cargo/sync-venv
+          VENV_PYTHON=.cargo/sync-venv/bin/python
+          if [ ! -x "$VENV_PYTHON" ]; then
+            VENV_PYTHON=.cargo/sync-venv/Scripts/python.exe
+          fi
+          "$VENV_PYTHON" -m pip install tomlkit requests InquirerPy
+          "$VENV_PYTHON" scripts/sync-versions.py \
+            --prepare-local-patches .cargo/tidesdb-src \
+            --write-cargo-patch-config .cargo/config.toml \
+            --versions current \
+            --yes
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 target/
 Cargo.lock
+__pycache__/
+*.py[cod]
 *.swp
 *.swo
 *~

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tidesdb"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 authors = ["TidesDB <hello@tidesdb.com>"]
 description = "TidesDB is a high-performance embeddable, durable, adaptive, and optionally cloud-native key-value storage engine"
@@ -19,9 +19,32 @@ thiserror = "1.0"
 [build-dependencies]
 pkg-config = "0.3"
 cmake = "0.1"
-ureq = "2"
 flate2 = "1"
 tar = "0.4"
+cfg-if = "1"
+tidesdb-src-v9-0-0 = {version = "0.1", optional = true}
+tidesdb-src-v9-0-1 = {version = "0.1", optional = true}
+tidesdb-src-v9-0-2 = {version = "0.1", optional = true}
+tidesdb-src-v9-0-3 = {version = "0.1", optional = true}
+tidesdb-src-v9-0-4 = {version = "0.1", optional = true}
+tidesdb-src-v9-0-5 = {version = "0.1", optional = true}
+tidesdb-src-v9-0-6 = {version = "0.1", optional = true}
+tidesdb-src-v9-0-7 = {version = "0.1", optional = true}
+tidesdb-src-v9-0-8 = {version = "0.1", optional = true}
+tidesdb-src-v9-0-9 = {version = "0.1", optional = true}
+tidesdb-src-v9-1-0 = {version = "0.1", optional = true}
+tidesdb-src-v9-2-0 = {version = "0.1", optional = true}
+tidesdb-src-v9-2-1 = {version = "0.1", optional = true}
+tidesdb-src-v9-2-2 = {version = "0.1", optional = true}
+tidesdb-src-v9-2-3 = {version = "0.1", optional = true}
+tidesdb-src-v9-2-4 = {version = "0.1", optional = true}
+tidesdb-src-v9-2-5 = {version = "0.1", optional = true}
+tidesdb-src-v9-3-0 = {version = "0.1", optional = true}
+tidesdb-src-v9-3-1 = {version = "0.1", optional = true}
+tidesdb-src-v9-3-2 = {version = "0.1", optional = true}
+tidesdb-src-v9-3-3 = {version = "0.1", optional = true}
+tidesdb-src-v9-3-4 = {version = "0.1", optional = true}
+tidesdb-src-v9-3-5 = {version = "0.1", optional = true}
 
 [dev-dependencies]
 tempfile = "3.10"
@@ -29,29 +52,29 @@ tempfile = "3.10"
 [features]
 default = ["v9_3_5"]
 objectstore = []
-v9_0_0 = []
-v9_0_1 = []
-v9_0_2 = []
-v9_0_3 = []
-v9_0_4 = []
-v9_0_5 = []
-v9_0_6 = []
-v9_0_7 = []
-v9_0_8 = []
-v9_0_9 = []
-v9_1_0 = []
-v9_2_0 = []
-v9_2_1 = []
-v9_2_2 = []
-v9_2_3 = []
-v9_2_4 = []
-v9_2_5 = []
-v9_3_0 = []
-v9_3_1 = []
-v9_3_2 = []
-v9_3_3 = []
-v9_3_4 = []
-v9_3_5 = []
+v9_0_0 = ["dep:tidesdb-src-v9-0-0"]
+v9_0_1 = ["dep:tidesdb-src-v9-0-1"]
+v9_0_2 = ["dep:tidesdb-src-v9-0-2"]
+v9_0_3 = ["dep:tidesdb-src-v9-0-3"]
+v9_0_4 = ["dep:tidesdb-src-v9-0-4"]
+v9_0_5 = ["dep:tidesdb-src-v9-0-5"]
+v9_0_6 = ["dep:tidesdb-src-v9-0-6"]
+v9_0_7 = ["dep:tidesdb-src-v9-0-7"]
+v9_0_8 = ["dep:tidesdb-src-v9-0-8"]
+v9_0_9 = ["dep:tidesdb-src-v9-0-9"]
+v9_1_0 = ["dep:tidesdb-src-v9-1-0"]
+v9_2_0 = ["dep:tidesdb-src-v9-2-0"]
+v9_2_1 = ["dep:tidesdb-src-v9-2-1"]
+v9_2_2 = ["dep:tidesdb-src-v9-2-2"]
+v9_2_3 = ["dep:tidesdb-src-v9-2-3"]
+v9_2_4 = ["dep:tidesdb-src-v9-2-4"]
+v9_2_5 = ["dep:tidesdb-src-v9-2-5"]
+v9_3_0 = ["dep:tidesdb-src-v9-3-0"]
+v9_3_1 = ["dep:tidesdb-src-v9-3-1"]
+v9_3_2 = ["dep:tidesdb-src-v9-3-2"]
+v9_3_3 = ["dep:tidesdb-src-v9-3-3"]
+v9_3_4 = ["dep:tidesdb-src-v9-3-4"]
+v9_3_5 = ["dep:tidesdb-src-v9-3-5"]
 
 [lib]
 name = "tidesdb"

--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,7 @@ fn selected_version() -> String {
     }
     match selected {
         Some((a, b, c)) => format!("{a}.{b}.{c}"),
-        None => "9.2.0".to_string(),
+        None => "9.3.5".to_string(),
     }
 }
 
@@ -40,35 +40,153 @@ fn version_at_least(version: &str, major: u32, minor: u32, patch: u32) -> bool {
     parse_version(version).is_some_and(|v| v >= (major, minor, patch))
 }
 
-fn download_and_extract(version: &str, out_dir: &str) -> PathBuf {
-    let url = format!("https://github.com/tidesdb/tidesdb/archive/refs/tags/v{version}.tar.gz");
-    let tarball_path = PathBuf::from(out_dir).join(format!("tidesdb-{version}.tar.gz"));
-    let extract_dir = PathBuf::from(out_dir).join("tidesdb-source");
+// BEGIN GENERATED TIDESDB SOURCE ARCHIVES
+cfg_if::cfg_if! {
+    if #[cfg(feature = "v9_3_5")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_3_5::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_3_4")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_3_4::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_3_3")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_3_3::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_3_2")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_3_2::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_3_1")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_3_1::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_3_0")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_3_0::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_2_5")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_2_5::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_2_4")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_2_4::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_2_3")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_2_3::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_2_2")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_2_2::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_2_1")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_2_1::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_2_0")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_2_0::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_1_0")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_1_0::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_0_9")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_0_9::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_0_8")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_0_8::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_0_7")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_0_7::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_0_6")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_0_6::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_0_5")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_0_5::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_0_4")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_0_4::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_0_3")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_0_3::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_0_2")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_0_2::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_0_1")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_0_1::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_0_0")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_0_0::archive_path()
+        }
+    }
+    else {
+        fn source_archive() -> PathBuf {
+            panic!("no tidesdb source crate is enabled; enable a vX_Y_Z feature")
+        }
+    }
+}
 
-    // Skip download if already extracted
+// END GENERATED TIDESDB SOURCE ARCHIVES
+
+fn extract_archive(version: &str, out_dir: &str) -> PathBuf {
+    let archive_path = source_archive();
+    let extract_dir = PathBuf::from(out_dir).join("tidesdb-source");
     let src_dir = extract_dir.join(format!("tidesdb-{version}"));
+
     if src_dir.exists() {
         return src_dir;
     }
 
-    // Download
-    let resp = ureq::get(&url)
-        .call()
-        .unwrap_or_else(|e| panic!("Failed to download tidesdb v{version} from {url}: {e}"));
-    let mut tarball = std::fs::File::create(&tarball_path).expect("Failed to create tarball file");
-    std::io::copy(&mut resp.into_reader(), &mut tarball).expect("Failed to write tarball");
-
-    // Extract
-    let tarball = std::fs::File::open(&tarball_path).expect("Failed to open tarball");
+    let tarball = std::fs::File::open(&archive_path).unwrap_or_else(|e| {
+        panic!(
+            "failed to open TidesDB v{version} source archive {}: {e}",
+            archive_path.display()
+        )
+    });
     let decoder = flate2::read::GzDecoder::new(tarball);
     let mut archive = tar::Archive::new(decoder);
     std::fs::create_dir_all(&extract_dir).expect("Failed to create extract directory");
     archive
         .unpack(&extract_dir)
-        .expect("Failed to extract tarball");
-
-    // Clean up tarball
-    let _ = std::fs::remove_file(&tarball_path);
+        .expect("Failed to extract TidesDB source archive");
 
     src_dir
 }
@@ -79,7 +197,7 @@ fn with_objectstore() -> bool {
 
 fn build_from_source(version: &str) -> PathBuf {
     let out_dir = std::env::var("OUT_DIR").unwrap();
-    let src_dir = download_and_extract(version, &out_dir);
+    let src_dir = extract_archive(version, &out_dir);
 
     let mut cfg = cmake::Config::new(&src_dir);
     cfg.define("TIDESDB_BUILD_TESTS", "OFF")

--- a/scripts/sync-versions.py
+++ b/scripts/sync-versions.py
@@ -8,55 +8,417 @@
 # ]
 # ///
 
-"""Sync tidesdb version feature gates with GitHub releases.
+"""Sync tidesdb version features and source crates.
 
-Fetches all releases from tidesdb/tidesdb, presents an interactive picker
-for which versions to include as Cargo feature gates, and updates Cargo.toml
-and the build.rs fallback default accordingly.
+Fetches TidesDB releases and crates.io state, presents a plan, updates
+Cargo.toml/build.rs so each version feature enables a matching tidesdb source
+archive crate, and optionally prepares missing or changed source crates. Prepared
+crates are checked with cargo publish --dry-run unless --publish is set.
+
+Flow:
+
+  start
+    |
+    v
+  fetch TidesDB GitHub releases
+    |
+    v
+  read current Cargo.toml features/default
+    |
+    +-- --prepare-local-patches?
+    |     |
+    |     v
+    |   write local source crates for selected versions
+    |     |
+    |   write optional .cargo/config.toml [patch.crates-io] entries
+    |     |
+    |     v
+    |   done
+    |
+    v
+  choose versions/default/source-crate set
+    |            |
+    |            +-- --versions: use CLI inputs and defaults,
+    |            |               then survey selected source crates
+    |            |
+    |            +-- no --versions: survey all source crates,
+    |                            then use interactive pickers
+    |
+    v
+  print plan
+    |
+    +-- any selected crate state unknown? -> abort before writes/publish
+    |
+    +-- --dry-run? -> exit after plan
+    |
+    v
+  confirm plan unless --yes
+    |
+    +-- not --source-crates-only -> update Cargo.toml, build.rs, and CI default
+    |
+    v
+  root files are current or intentionally skipped
+    |
+    +-- no source crates selected? -> done
+    |
+    v
+  prepare each selected source crate in work dir
+    |
+    v
+  cargo publish --dry-run each prepared crate unless --publish is set
+    |
+    v
+  clean temp work dir, or keep explicit/requested work dir
+    |
+    v
+  done
 """
 
+from __future__ import annotations
+
 import argparse
+import copy
+import hashlib
+import io
 import re
-import tomlkit
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
 import requests
+import tomlkit
 from InquirerPy import inquirer
 
-CARGO_TOML = "Cargo.toml"
-BUILD_RS = "build.rs"
-BUILD_AND_TEST_YML = ".github/workflows/build_and_test.yml"
+CARGO_TOML = Path("Cargo.toml")
+BUILD_RS = Path("build.rs")
+BUILD_AND_TEST_YML = Path(".github/workflows/build_and_test.yml")
+LICENSE = Path("LICENSE")
 REPO = "tidesdb/tidesdb"
+SOURCE_CRATE_INITIAL_VERSION = "0.1.0"
+CRATES_IO = "https://crates.io/api/v1/crates"
+USER_AGENT = "tidesdb-rs source-crate sync (https://github.com/tidesdb/tidesdb-rs)"
 
 
-def fetch_versions() -> list[str]:
-    """Fetch all release versions from GitHub, sorted ascending."""
+@dataclass
+class ArchiveInfo:
+    data: bytes
+    size: int
+    sha256: str
+
+
+@dataclass
+class SourceCrateState:
+    status: str
+    published_version: str | None = None
+    publish_version: str | None = None
+    reasons: list[str] = field(default_factory=list)
+
+    @property
+    def needs_publish(self) -> bool:
+        return self.status in {"missing", "update"}
+
+    @property
+    def is_blocking(self) -> bool:
+        return self.status == "unknown"
+
+
+def versions_from_releases(releases: Iterable[dict]) -> list[str]:
+    return versions_from_tags(release["tag_name"] for release in releases)
+
+
+def versions_from_tags(tags: Iterable[str]) -> list[str]:
     versions = []
+    for tag in tags:
+        if not tag.startswith("v"):
+            continue
+        version = tag[1:]
+        if not is_version(version):
+            continue
+        if int(version.split(".")[0]) < 9:
+            continue
+        versions.append(version)
+
+    return sorted(set(versions), key=version_key)
+
+
+def fetch_versions_with_gh() -> list[str] | None:
+    if shutil.which("gh") is None:
+        return None
+
+    cmd = [
+        "gh",
+        "api",
+        "--method",
+        "GET",
+        "--paginate",
+        f"repos/{REPO}/releases",
+        "-f",
+        "per_page=100",
+        "--jq",
+        ".[].tag_name",
+    ]
+    try:
+        output = subprocess.check_output(cmd, text=True, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"warning: gh release query failed, falling back to GitHub API: {exc.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return None
+
+    return versions_from_tags(output.splitlines())
+
+
+def fetch_versions_with_requests() -> list[str]:
     url = f"https://api.github.com/repos/{REPO}/releases"
     page = 1
+    releases = []
     while True:
-        resp = requests.get(url, params={"per_page": 100, "page": page})
+        resp = requests.get(
+            url,
+            params={"per_page": 100, "page": page},
+            headers={"User-Agent": USER_AGENT},
+            timeout=30,
+        )
         resp.raise_for_status()
         data = resp.json()
         if not data:
             break
-        for release in data:
-            tag = release["tag_name"]
-            if not tag.startswith("v"):
-                continue
-            ver = tag[1:]
-            parts = ver.split(".")
-            if len(parts) != 3:
-                continue
-            try:
-                major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
-            except ValueError:
-                continue
-            if major < 9:
-                continue
-            versions.append(ver)
+        releases.extend(data)
         page += 1
 
-    versions.sort(key=lambda v: list(map(int, v.split("."))))
-    return versions
+    return versions_from_releases(releases)
+
+
+def fetch_versions() -> list[str]:
+    """Fetch all TidesDB release versions from GitHub, sorted ascending."""
+    versions = fetch_versions_with_gh()
+    if versions is not None:
+        return versions
+    return fetch_versions_with_requests()
+
+
+def fetch_crate_api(name: str) -> dict | None:
+    resp = requests.get(
+        f"{CRATES_IO}/{name}",
+        headers={"User-Agent": USER_AGENT},
+        timeout=30,
+    )
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    return resp.json()
+
+
+def latest_published_version(crate: dict) -> str | None:
+    versions = [
+        version["num"]
+        for version in crate.get("versions", [])
+        if not version.get("yanked", False)
+    ]
+    if not versions:
+        return None
+    return sorted(versions, key=version_key)[-1]
+
+
+def bump_patch(version: str) -> str:
+    major, minor, patch = version_key(version)
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def fetch_published_crate_bytes(name: str, version: str) -> bytes:
+    url = f"{CRATES_IO}/{name}/{version}/download"
+    resp = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=60)
+    resp.raise_for_status()
+    return resp.content
+
+
+def read_member_bytes(crate_bytes: bytes, member_name: str) -> bytes | None:
+    with tarfile.open(fileobj=io.BytesIO(crate_bytes), mode="r:gz") as archive:
+        for member in archive.getmembers():
+            if member.name.endswith(f"/{member_name}"):
+                file = archive.extractfile(member)
+                return file.read() if file else None
+    return None
+
+
+def expected_manifest(version: str, package_version: str) -> str:
+    crate_name = source_crate_name(version)
+    cargo = tomlkit.document()
+    package = tomlkit.table()
+    package["name"] = crate_name
+    package["version"] = package_version
+    package["edition"] = "2024"
+    package["authors"] = ["TidesDB <hello@tidesdb.com>"]
+    package["description"] = f"Vendored TidesDB C source archive for v{version}"
+    package["license"] = "MPL-2.0"
+    package["repository"] = "https://github.com/tidesdb/tidesdb-rs"
+    package["homepage"] = "https://tidesdb.com"
+    package["readme"] = "README.md"
+    package["keywords"] = ["database", "key-value", "tidesdb", "source"]
+    package["categories"] = ["database", "external-ffi-bindings"]
+    package["include"] = ["src/**", "vendor/**", "Cargo.toml", "README.md", "LICENSE"]
+    cargo["package"] = package
+    cargo["lib"] = {"path": "src/lib.rs"}
+    return tomlkit.dumps(cargo)
+
+
+def expected_lib_rs(version: str) -> str:
+    archive_name = source_archive_name(version)
+    return (
+        "use std::path::{Path, PathBuf};\n\n"
+        f"pub const TIDESDB_VERSION: &str = \"{version}\";\n"
+        f"pub const ARCHIVE_NAME: &str = \"{archive_name}\";\n\n"
+        "pub fn archive_path() -> PathBuf {\n"
+        "    Path::new(env!(\"CARGO_MANIFEST_DIR\"))\n"
+        "        .join(\"vendor\")\n"
+        "        .join(ARCHIVE_NAME)\n"
+        "}\n"
+    )
+
+
+def comparable_manifest(content: bytes, package_version: str) -> dict:
+    data = tomlkit.loads(content.decode("utf-8"))
+    package = to_plain(data["package"])
+    package.pop("version", None)
+    package["version"] = package_version
+    return {
+        "package": package,
+        "lib": to_plain(data.get("lib", {})),
+    }
+
+
+def to_plain(value):
+    if isinstance(value, dict):
+        return {str(key): to_plain(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [to_plain(item) for item in value]
+    return value.unwrap() if hasattr(value, "unwrap") else value
+
+
+def archive_info(data: bytes) -> ArchiveInfo:
+    return ArchiveInfo(
+        data=data,
+        size=len(data),
+        sha256=hashlib.sha256(data).hexdigest(),
+    )
+
+
+def compare_published_crate(
+    version: str,
+    published_version: str,
+    published_bytes: bytes,
+    source_archive: ArchiveInfo,
+) -> list[str]:
+    reasons = []
+
+    manifest = (
+        read_member_bytes(published_bytes, "Cargo.toml.orig")
+        or read_member_bytes(published_bytes, "Cargo.toml")
+    )
+    if manifest is None:
+        reasons.append("published crate is missing Cargo.toml")
+    else:
+        expected = comparable_manifest(
+            expected_manifest(version, published_version).encode("utf-8"),
+            published_version,
+        )
+        actual = comparable_manifest(manifest, published_version)
+        if actual != expected:
+            reasons.append("package metadata differs")
+
+    lib_rs = read_member_bytes(published_bytes, "src/lib.rs")
+    if lib_rs is None:
+        reasons.append("published crate is missing src/lib.rs")
+    elif lib_rs.decode("utf-8") != expected_lib_rs(version):
+        reasons.append("src/lib.rs metadata differs")
+
+    archive = read_member_bytes(published_bytes, f"vendor/{source_archive_name(version)}")
+    if archive is None:
+        reasons.append("published crate is missing vendored archive")
+    else:
+        published_archive = archive_info(archive)
+        if published_archive.size != source_archive.size:
+            reasons.append(
+                f"vendored archive size differs ({published_archive.size} != {source_archive.size})"
+            )
+        if published_archive.sha256 != source_archive.sha256:
+            reasons.append(
+                "vendored archive sha256 differs "
+                f"({published_archive.sha256} != {source_archive.sha256})"
+            )
+
+    return reasons
+
+
+def fetch_crates_state(versions: Iterable[str]) -> dict[str, SourceCrateState]:
+    state = {}
+    for version in versions:
+        name = source_crate_name(version)
+        try:
+            crate = fetch_crate_api(name)
+            if crate is None:
+                state[version] = SourceCrateState(
+                    status="missing",
+                    publish_version=SOURCE_CRATE_INITIAL_VERSION,
+                    reasons=["crate is not published"],
+                )
+                continue
+
+            published_version = latest_published_version(crate)
+            if published_version is None:
+                state[version] = SourceCrateState(
+                    status="missing",
+                    publish_version=SOURCE_CRATE_INITIAL_VERSION,
+                    reasons=["crate has no non-yanked published versions"],
+                )
+                continue
+
+            source_archive = download_archive_info(version)
+            published_bytes = fetch_published_crate_bytes(name, published_version)
+            reasons = compare_published_crate(
+                version,
+                published_version,
+                published_bytes,
+                source_archive,
+            )
+            if reasons:
+                state[version] = SourceCrateState(
+                    status="update",
+                    published_version=published_version,
+                    publish_version=bump_patch(published_version),
+                    reasons=reasons,
+                )
+            else:
+                state[version] = SourceCrateState(
+                    status="current",
+                    published_version=published_version,
+                    publish_version=published_version,
+                )
+        except requests.HTTPError as exc:
+            print(f"warning: failed to query crates.io for {name}: {exc}", file=sys.stderr)
+            state[version] = SourceCrateState(
+                status="unknown",
+                reasons=[f"crates.io query failed: {exc}"],
+            )
+    return state
+
+
+def is_version(value: str) -> bool:
+    parts = value.split(".")
+    if len(parts) != 3:
+        return False
+    return all(part.isdigit() for part in parts)
+
+
+def version_key(version: str) -> tuple[int, int, int]:
+    major, minor, patch = version.split(".")
+    return int(major), int(minor), int(patch)
 
 
 def version_to_feature(version: str) -> str:
@@ -67,95 +429,531 @@ def feature_to_version(feature: str) -> str:
     return feature[1:].replace("_", ".")
 
 
+def source_crate_name(version: str) -> str:
+    return "tidesdb-src-v" + version.replace(".", "-")
+
+
+def source_crate_rust_name(version: str) -> str:
+    return source_crate_name(version).replace("-", "_")
+
+
+def source_archive_name(version: str) -> str:
+    return f"tidesdb-{version}.tar.gz"
+
+
+def parse_versions(value: str, current: list[str], all_versions: list[str]) -> list[str]:
+    if value == "current":
+        return current
+    if value == "all":
+        return all_versions
+
+    selected = []
+    for raw in value.split(","):
+        version = raw.strip().removeprefix("v").replace("_", ".")
+        if not version:
+            continue
+        if not is_version(version):
+            raise SystemExit(f"invalid version: {raw}")
+        selected.append(version)
+    return sorted(set(selected), key=version_key)
+
+
+def parse_publish_versions(value: str, selected: list[str], needed: list[str], missing: list[str]) -> list[str]:
+    if value == "none":
+        return []
+    if value == "needed":
+        return needed
+    if value == "missing":
+        return missing
+    if value == "selected":
+        return [version for version in selected if version in needed]
+
+    versions = parse_versions(value, current=selected, all_versions=selected)
+    unselected = sorted(set(versions) - set(selected), key=version_key)
+    if unselected:
+        raise SystemExit(
+            "--publish-versions must be a subset of --versions: "
+            + ", ".join(unselected)
+        )
+    not_needed = sorted(set(versions) - set(needed), key=version_key)
+    if not_needed:
+        raise SystemExit(
+            "selected source crates do not need publish/update: "
+            + ", ".join(not_needed)
+        )
+    return versions
+
+
 def load_cargo_toml() -> tomlkit.TOMLDocument:
-    with open(CARGO_TOML, "r") as f:
+    with CARGO_TOML.open("r") as f:
         return tomlkit.load(f)
 
 
 def save_cargo_toml(data: tomlkit.TOMLDocument):
-    with open(CARGO_TOML, "w") as f:
+    with CARGO_TOML.open("w") as f:
         tomlkit.dump(data, f)
 
 
 def current_version_features(cargo: dict) -> set[str]:
-    """Return the set of version features currently in Cargo.toml."""
-    features = set()
-    for key in cargo.get("features", {}):
-        if re.match(r"^v\d+_\d+_\d+$", key):
-            features.add(key)
-    return features
+    return {
+        key
+        for key in cargo.get("features", {})
+        if re.match(r"^v\d+_\d+_\d+$", key)
+    }
 
 
-def current_default_version(cargo: dict) -> str | None:
-    """Return the current default version feature, if any."""
-    for feat in cargo.get("features", {}).get("default", []):
-        if re.match(r"^v\d+_\d+_\d+$", feat):
-            return feat
+def current_versions(cargo: dict) -> list[str]:
+    return sorted(
+        [feature_to_version(feature) for feature in current_version_features(cargo)],
+        key=version_key,
+    )
+
+
+def current_default_feature(cargo: dict) -> str | None:
+    for feature in cargo.get("features", {}).get("default", []):
+        if re.match(r"^v\d+_\d+_\d+$", feature):
+            return feature
     return None
 
 
-def update_build_rs_default(version: str):
-    """Update the fallback default version in build.rs."""
-    with open(BUILD_RS, "r") as f:
-        content = f.read()
+def source_crate_requirement(version: str, state: SourceCrateState | None) -> str:
+    package_version = (
+        state.publish_version
+        if state and state.publish_version
+        else SOURCE_CRATE_INITIAL_VERSION
+    )
+    major, minor, _ = version_key(package_version)
+    return f"{major}.{minor}"
 
+
+def dependency_value(version: str, state: SourceCrateState | None):
+    value = tomlkit.inline_table()
+    value["version"] = source_crate_requirement(version, state)
+    value["optional"] = True
+    return value
+
+
+def update_cargo_toml(
+    cargo: tomlkit.TOMLDocument,
+    versions: list[str],
+    default_version: str,
+    crates_state: dict[str, SourceCrateState],
+):
+    build_deps = cargo.setdefault("build-dependencies", tomlkit.table())
+    if "ureq" in build_deps:
+        del build_deps["ureq"]
+    build_deps["cfg-if"] = "1"
+
+    for key in list(build_deps.keys()):
+        if re.match(r"^tidesdb-src-v\d+-\d+-\d+$", key):
+            del build_deps[key]
+
+    deps = cargo.setdefault("dependencies", tomlkit.table())
+    for key in list(deps.keys()):
+        if re.match(r"^tidesdb-src-v\d+-\d+-\d+$", key):
+            del deps[key]
+
+    for version in versions:
+        build_deps[source_crate_name(version)] = dependency_value(version, crates_state.get(version))
+
+    features = cargo.setdefault("features", tomlkit.table())
+    for key in list(features.keys()):
+        if re.match(r"^v\d+_\d+_\d+$", key):
+            del features[key]
+
+    new_default = [
+        feature
+        for feature in features.get("default", [])
+        if not re.match(r"^v\d+_\d+_\d+$", feature)
+    ]
+    new_default.append(version_to_feature(default_version))
+    features["default"] = new_default
+
+    for version in versions:
+        features[version_to_feature(version)] = [f"dep:{source_crate_name(version)}"]
+
+
+def render_cargo_toml(
+    cargo: tomlkit.TOMLDocument,
+    versions: list[str],
+    default_version: str,
+    crates_state: dict[str, SourceCrateState],
+) -> str:
+    rendered = copy.deepcopy(cargo)
+    update_cargo_toml(rendered, versions, default_version, crates_state)
+    return tomlkit.dumps(rendered)
+
+
+def source_archive_function(versions: list[str]) -> str:
+    branches = []
+    for version in reversed(versions):
+        feature = version_to_feature(version)
+        crate = source_crate_rust_name(version)
+        keyword = "if" if not branches else "else if"
+        branches.append(
+            f'    {keyword} #[cfg(feature = "{feature}")] {{\n'
+            "        fn source_archive() -> PathBuf {\n"
+            f"            {crate}::archive_path()\n"
+            "        }\n"
+            "    }"
+        )
+    branch_text = "\n".join(branches)
+    return (
+        "cfg_if::cfg_if! {\n"
+        f"{branch_text}\n"
+        "    else {\n"
+        "        fn source_archive() -> PathBuf {\n"
+        "            panic!(\"no tidesdb source crate is enabled; enable a vX_Y_Z feature\")\n"
+        "        }\n"
+        "    }\n"
+        "}\n"
+    )
+
+
+def extraction_functions(versions: list[str]) -> str:
+    return (
+        "// BEGIN GENERATED TIDESDB SOURCE ARCHIVES\n"
+        f"{source_archive_function(versions)}\n"
+        "// END GENERATED TIDESDB SOURCE ARCHIVES\n\n"
+        "fn extract_archive(version: &str, out_dir: &str) -> PathBuf {\n"
+        "    let archive_path = source_archive();\n"
+        "    let extract_dir = PathBuf::from(out_dir).join(\"tidesdb-source\");\n"
+        "    let src_dir = extract_dir.join(format!(\"tidesdb-{version}\"));\n\n"
+        "    if src_dir.exists() {\n"
+        "        return src_dir;\n"
+        "    }\n\n"
+        "    let tarball = std::fs::File::open(&archive_path).unwrap_or_else(|e| {\n"
+        "        panic!(\n"
+        "            \"failed to open TidesDB v{version} source archive {}: {e}\",\n"
+        "            archive_path.display()\n"
+        "        )\n"
+        "    });\n"
+        "    let decoder = flate2::read::GzDecoder::new(tarball);\n"
+        "    let mut archive = tar::Archive::new(decoder);\n"
+        "    std::fs::create_dir_all(&extract_dir).expect(\"Failed to create extract directory\");\n"
+        "    archive\n"
+        "        .unpack(&extract_dir)\n"
+        "        .expect(\"Failed to extract TidesDB source archive\");\n\n"
+        "    src_dir\n"
+        "}\n"
+    )
+
+
+def render_build_rs(content: str, versions: list[str], default_version: str) -> str:
     content = re.sub(
-        r'selected\.unwrap_or_else\(\|\| "[\d.]+"\.to_string\(\)\)',
-        f'selected.unwrap_or_else(|| "{version}".to_string())',
+        r'None => "[\d.]+"\.to_string\(\)',
+        f'None => "{default_version}".to_string()',
         content,
     )
 
-    with open(BUILD_RS, "w") as f:
-        f.write(content)
+    generated = extraction_functions(versions)
+    if "BEGIN GENERATED TIDESDB SOURCE ARCHIVES" in content:
+        content = re.sub(
+            r"// BEGIN GENERATED TIDESDB SOURCE ARCHIVES\n.*?// END GENERATED TIDESDB SOURCE ARCHIVES\n\n"
+            r"fn extract_archive\(version: &str, out_dir: &str\) -> PathBuf \{\n.*?\n\}\n",
+            generated,
+            content,
+            flags=re.S,
+        )
+    else:
+        content = re.sub(
+            r"fn download_and_extract\(version: &str, out_dir: &str\) -> PathBuf \{\n.*?\n\}\n\n",
+            generated + "\n",
+            content,
+            flags=re.S,
+        )
+
+    content = content.replace(
+        "let src_dir = download_and_extract(version, &out_dir);",
+        "let src_dir = extract_archive(version, &out_dir);",
+    )
+
+    return content
+
+
+def update_build_rs(versions: list[str], default_version: str):
+    BUILD_RS.write_text(render_build_rs(BUILD_RS.read_text(), versions, default_version))
+
+
+def files_to_modify_for_plan(
+    cargo: tomlkit.TOMLDocument,
+    selected_versions: list[str],
+    default_version: str,
+    crates_state: dict[str, SourceCrateState],
+) -> list[Path]:
+    files = []
+    if render_cargo_toml(cargo, selected_versions, default_version, crates_state) != CARGO_TOML.read_text():
+        files.append(CARGO_TOML)
+    if render_build_rs(BUILD_RS.read_text(), selected_versions, default_version) != BUILD_RS.read_text():
+        files.append(BUILD_RS)
+    if BUILD_AND_TEST_YML.exists():
+        current_default = current_default_feature(cargo)
+        if current_default != version_to_feature(default_version):
+            files.append(BUILD_AND_TEST_YML)
+    return files
 
 
 def update_ci_default(version: str):
-    """Update the pinned tidesdb ref in build_and_test CI workflow."""
-    import os
-    if not os.path.exists(BUILD_AND_TEST_YML):
+    if not BUILD_AND_TEST_YML.exists():
         return
 
-    with open(BUILD_AND_TEST_YML, "r") as f:
-        content = f.read()
-
+    content = BUILD_AND_TEST_YML.read_text()
     content = re.sub(
         r"(repository: tidesdb/tidesdb\s+ref: )v[\d.]+",
         rf"\g<1>v{version}",
         content,
     )
-
-    with open(BUILD_AND_TEST_YML, "w") as f:
-        f.write(content)
+    BUILD_AND_TEST_YML.write_text(content)
 
 
-def main():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--dry-run", action="store_true",
-        help="Show what would be changed without writing files",
+def download_archive(version: str, destination: Path):
+    info = download_archive_info(version)
+    destination.write_bytes(info.data)
+
+
+def download_archive_info(version: str) -> ArchiveInfo:
+    url = f"https://github.com/{REPO}/archive/refs/tags/v{version}.tar.gz"
+    with requests.get(url, headers={"User-Agent": USER_AGENT}, stream=True, timeout=60) as resp:
+        resp.raise_for_status()
+        data = b"".join(chunk for chunk in resp.iter_content(chunk_size=1024 * 1024) if chunk)
+    return archive_info(data)
+
+
+def write_source_crate(
+    version: str,
+    package_version: str,
+    root: Path,
+    *,
+    include_archive: bool = True,
+):
+    crate_name = source_crate_name(version)
+    crate_dir = root / crate_name
+    if crate_dir.exists():
+        shutil.rmtree(crate_dir)
+    vendor_dir = crate_dir / "vendor"
+    src_dir = crate_dir / "src"
+    vendor_dir.mkdir(parents=True)
+    src_dir.mkdir(parents=True)
+
+    archive_name = source_archive_name(version)
+    if include_archive:
+        download_archive(version, vendor_dir / archive_name)
+
+    (crate_dir / "Cargo.toml").write_text(expected_manifest(version, package_version))
+
+    (crate_dir / "README.md").write_text(
+        f"# {crate_name}\n\n"
+        f"This crate packages the TidesDB C source archive for `v{version}`.\n\n"
+        "It is intended as a build-dependency of the `tidesdb` Rust bindings.\n"
     )
-    args = parser.parse_args()
 
-    print(f"Fetching releases from {REPO}...")
-    all_versions = fetch_versions()
-    print(f"Found {len(all_versions)} releases.\n")
+    if LICENSE.exists():
+        shutil.copyfile(LICENSE, crate_dir / "LICENSE")
 
-    cargo = load_cargo_toml()
-    existing_features = current_version_features(cargo)
-    current_default = current_default_version(cargo)
+    (src_dir / "lib.rs").write_text(expected_lib_rs(version))
 
-    # Build choices for the checkbox picker
+    return crate_dir
+
+
+def dependency_version(cargo: tomlkit.TOMLDocument, version: str) -> str:
+    crate_name = source_crate_name(version)
+    dependency = cargo.get("build-dependencies", {}).get(crate_name)
+    if isinstance(dependency, str):
+        requirement = dependency
+    elif isinstance(dependency, dict):
+        requirement = dependency.get("version", SOURCE_CRATE_INITIAL_VERSION)
+    else:
+        requirement = SOURCE_CRATE_INITIAL_VERSION
+
+    match = re.fullmatch(r"(\d+)\.(\d+)(?:\.(\d+))?", str(requirement))
+    if not match:
+        return SOURCE_CRATE_INITIAL_VERSION
+
+    major, minor, patch = match.groups()
+    return f"{major}.{minor}.{patch or 0}"
+
+
+def parse_local_patch_archive_versions(
+    value: str,
+    *,
+    selected_versions: list[str],
+    default_version: str,
+) -> set[str]:
+    if value == "all":
+        return set(selected_versions)
+    if value == "current":
+        return set(selected_versions)
+    if value == "default":
+        return {default_version}
+    if value == "none":
+        return set()
+    return set(parse_versions(value, current=selected_versions, all_versions=selected_versions))
+
+
+def write_cargo_patch_config(config_path: Path, crate_dirs: dict[str, Path]):
+    if config_path.exists():
+        config = tomlkit.parse(config_path.read_text())
+    else:
+        config = tomlkit.document()
+
+    patch = config.setdefault("patch", tomlkit.table())
+    crates_io = patch.setdefault("crates-io", tomlkit.table())
+
+    for key in list(crates_io.keys()):
+        if re.match(r"^tidesdb-src-v\d+-\d+-\d+$", key):
+            del crates_io[key]
+
+    for version, crate_dir in sorted(crate_dirs.items(), key=lambda item: version_key(item[0])):
+        value = tomlkit.inline_table()
+        value["path"] = crate_dir.resolve().as_posix()
+        crates_io[source_crate_name(version)] = value
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(tomlkit.dumps(config))
+
+
+def prepare_local_patches(
+    cargo: tomlkit.TOMLDocument,
+    versions: list[str],
+    work_root: Path,
+    config_path: Path | None,
+    archive_versions: set[str],
+):
+    work_root.mkdir(parents=True, exist_ok=True)
+    crate_dirs = {}
+
+    for version in versions:
+        package_version = dependency_version(cargo, version)
+        include_archive = version in archive_versions
+        crate_dir = write_source_crate(
+            version,
+            package_version,
+            work_root,
+            include_archive=include_archive,
+        )
+        crate_dirs[version] = crate_dir
+        if include_archive:
+            print(f"Prepared {source_crate_name(version)}@{package_version} with vendored archive")
+        else:
+            print(f"Prepared {source_crate_name(version)}@{package_version} for dependency patching")
+
+    if config_path:
+        write_cargo_patch_config(config_path, crate_dirs)
+        print(f"Wrote Cargo patch config to {config_path}")
+
+
+def cargo_publish(crate_dir: Path, dry_run: bool):
+    cmd = ["cargo", "publish", "--manifest-path", str(crate_dir / "Cargo.toml")]
+    if dry_run:
+        cmd.append("--dry-run")
+    subprocess.run(cmd, check=True)
+
+
+def summarize(
+    selected_versions: list[str],
+    default_version: str,
+    existing_features: set[str],
+    crates_state: dict[str, SourceCrateState],
+    publish_versions: list[str],
+    files_to_modify: list[Path],
+    publish: bool,
+    source_crates_only: bool,
+):
+    selected_features = {version_to_feature(v) for v in selected_versions}
+    added = selected_features - existing_features
+    removed = existing_features - selected_features
+    current_crates = [
+        f"{source_crate_name(v)}@{crates_state[v].published_version}"
+        for v in selected_versions
+        if crates_state.get(v) and crates_state[v].status == "current"
+    ]
+    missing_crates = [
+        f"{source_crate_name(v)} -> {crates_state[v].publish_version}"
+        for v in selected_versions
+        if crates_state.get(v) and crates_state[v].status == "missing"
+    ]
+    unknown_crates = [
+        source_crate_name(v)
+        for v in selected_versions
+        if crates_state.get(v) and crates_state[v].status == "unknown"
+    ]
+    update_crates = [
+        f"{source_crate_name(v)} {crates_state[v].published_version} -> {crates_state[v].publish_version}"
+        for v in selected_versions
+        if crates_state.get(v) and crates_state[v].status == "update"
+    ]
+
+    print("\nPlan:")
+    print(f"  Version features: {', '.join(version_to_feature(v) for v in selected_versions)}")
+    print(f"  Default:          {version_to_feature(default_version)} ({default_version})")
+    if source_crates_only:
+        print("  Root changes:     skipped")
+    elif added:
+        print(f"  Add features:     {', '.join(sorted(added))}")
+    if not source_crates_only and removed:
+        print(f"  Remove features:  {', '.join(sorted(removed))}")
+    if current_crates:
+        print(f"  Current crates:   {', '.join(current_crates)}")
+    if missing_crates:
+        print(f"  Missing crates:   {', '.join(missing_crates)}")
+    if unknown_crates:
+        print(f"  Unknown crates:   {', '.join(unknown_crates)}")
+        for version in selected_versions:
+            state = crates_state.get(version)
+            if state and state.status == "unknown":
+                print(f"    {source_crate_name(version)}: {'; '.join(state.reasons)}")
+    if update_crates:
+        print(f"  Update crates:    {', '.join(update_crates)}")
+        for version in selected_versions:
+            state = crates_state.get(version)
+            if state and state.status == "update":
+                print(f"    {source_crate_name(version)}: {'; '.join(state.reasons)}")
+    if publish_versions:
+        action = "Publish crates" if publish else "Check crates"
+        print(
+            f"  {action}:     "
+            + ", ".join(
+                f"{source_crate_name(v)}@{crates_state[v].publish_version}"
+                for v in publish_versions
+            )
+        )
+    else:
+        print("  Publish/check:    none")
+    if source_crates_only:
+        files = "none (--source-crates-only)"
+    else:
+        files = ", ".join(str(path) for path in files_to_modify) if files_to_modify else "none"
+    print(f"  Files to modify:  {files}")
+
+
+def choose_interactively(
+    all_versions: list[str],
+    current: list[str],
+    current_default: str | None,
+    crates_state: dict[str, SourceCrateState],
+) -> tuple[list[str], str, list[str]]:
     choices = []
     for version in all_versions:
         feature = version_to_feature(version)
-        name = f"{feature} ({version})"
+        state = crates_state[version]
+        if state.status == "current":
+            status = f"published {state.published_version}"
+        elif state.status == "update":
+            status = f"update {state.published_version} -> {state.publish_version}"
+        elif state.status == "unknown":
+            status = "unknown; registry check failed"
+        else:
+            status = f"missing -> {state.publish_version}"
+        name = f"{feature} ({version}, {status})"
         if feature == current_default:
             name += " [current default]"
-        choices.append({
-            "name": name,
-            "value": version,
-            "enabled": feature in existing_features,
-        })
+        choices.append(
+            {
+                "name": name,
+                "value": version,
+                "enabled": version in current,
+            }
+        )
 
     selected_versions = inquirer.checkbox(
         message="Select version features:",
@@ -164,19 +962,11 @@ def main():
     ).execute()
 
     if not selected_versions:
-        print("No versions selected, aborting.")
-        return
+        raise SystemExit("No versions selected, aborting.")
 
-    selected_features = [version_to_feature(v) for v in selected_versions]
-
-    # Pick the default version
-    default_current = (
-        feature_to_version(current_default) if current_default else None
-    )
-    default_default = (
-        default_current if default_current in selected_versions
-        else selected_versions[-1]
-    )
+    selected_versions = sorted(selected_versions, key=version_key)
+    default_current = feature_to_version(current_default) if current_default else None
+    default_default = default_current if default_current in selected_versions else selected_versions[-1]
 
     default_version = inquirer.select(
         message="Select default version:",
@@ -186,64 +976,237 @@ def main():
         ],
         default=default_default,
     ).execute()
-    default_feature = version_to_feature(default_version)
 
-    # Show summary
-    print(f"\nVersion features: {', '.join(selected_features)}")
-    print(f"Default: {default_feature} ({default_version})")
+    needed = [version for version in selected_versions if crates_state[version].needs_publish]
+    publish_versions = []
+    if needed:
+        publish_versions = inquirer.checkbox(
+            message="Select source crates to publish/update:",
+            choices=[
+                {
+                    "name": (
+                        f"{source_crate_name(version)} "
+                        f"({crates_state[version].status}, "
+                        f"{crates_state[version].published_version or 'none'}"
+                        f" -> {crates_state[version].publish_version})"
+                    ),
+                    "value": version,
+                    "enabled": True,
+                }
+                for version in needed
+            ],
+            instruction="(Space to toggle, Enter to confirm)",
+        ).execute()
+        publish_versions = sorted(publish_versions, key=version_key)
 
-    # Compute changes
-    added = set(selected_features) - existing_features
-    removed = existing_features - set(selected_features)
-    default_changed = current_default != default_feature
+    return selected_versions, default_version, publish_versions
 
-    if not added and not removed and not default_changed:
-        print("\nNo changes needed.")
+
+def main():
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(line_buffering=True)
+
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show the plan without writing files or publishing crates")
+    parser.add_argument("--yes", action="store_true", help="Apply the plan without an interactive final confirmation")
+    parser.add_argument(
+        "--versions",
+        help="Comma-separated versions, 'current', or 'all'. Without this, use the interactive picker.",
+    )
+    parser.add_argument("--default-version", help="Default TidesDB version feature to enable")
+    parser.add_argument(
+        "--publish-versions",
+        default=None,
+        help="Comma-separated versions to prepare, 'needed', 'missing', 'selected', or 'none'. Defaults to needed in non-interactive mode.",
+    )
+    parser.add_argument("--skip-publish", action="store_true", help="Update files and prepare no crates")
+    parser.add_argument("--publish", action="store_true", help="Actually upload prepared crates to crates.io")
+    parser.add_argument("--publish-dry-run", action="store_true", help="Force cargo publish --dry-run for prepared crates")
+    parser.add_argument(
+        "--prepare-local-patches",
+        type=Path,
+        help="Prepare local source crates for Cargo dependency patching and exit",
+    )
+    parser.add_argument(
+        "--write-cargo-patch-config",
+        type=Path,
+        help="Write [patch.crates-io] entries pointing at prepared local source crates",
+    )
+    parser.add_argument(
+        "--local-patch-archive-versions",
+        default="default",
+        help="Versions whose local patch crates should include vendored archives: default, all, current, none, or a comma-separated list",
+    )
+    parser.add_argument(
+        "--source-crates-only",
+        action="store_true",
+        help="Only prepare/check/publish source crates; do not update Cargo.toml, build.rs, or CI",
+    )
+    parser.add_argument("--keep-work-dir", action="store_true", help="Keep prepared source crates instead of cleaning them up")
+    parser.add_argument("--work-dir", type=Path, help="Directory for prepared source crates")
+    args = parser.parse_args()
+
+    cargo = load_cargo_toml()
+    current = current_versions(cargo)
+    existing_features = current_version_features(cargo)
+    current_default = current_default_feature(cargo)
+    default_current = feature_to_version(current_default) if current_default else None
+
+    if args.prepare_local_patches:
+        selected_versions = parse_versions(
+            args.versions or "current",
+            current=current,
+            all_versions=current,
+        )
+        default_version = args.default_version or (
+            default_current if default_current in selected_versions else selected_versions[-1]
+        )
+        if default_version not in selected_versions:
+            raise SystemExit("--default-version must be one of the selected versions")
+        archive_versions = parse_local_patch_archive_versions(
+            args.local_patch_archive_versions,
+            selected_versions=selected_versions,
+            default_version=default_version,
+        )
+        prepare_local_patches(
+            cargo,
+            selected_versions,
+            args.prepare_local_patches,
+            args.write_cargo_patch_config,
+            archive_versions,
+        )
         return
 
-    # Show what would change
-    print("\nChanges:")
-    files_to_modify = []
-    if added:
-        print(f"  Add features:    {', '.join(sorted(added))}")
-    if removed:
-        print(f"  Remove features: {', '.join(sorted(removed))}")
-    if added or removed or default_changed:
-        files_to_modify.append(CARGO_TOML)
-    if default_changed:
-        print(f"  Default:         {current_default or '(none)'} -> {default_feature}")
-        files_to_modify.append(BUILD_RS)
-        files_to_modify.append(BUILD_AND_TEST_YML)
+    if args.write_cargo_patch_config:
+        raise SystemExit("--write-cargo-patch-config requires --prepare-local-patches")
 
-    print(f"\nFiles to modify: {', '.join(files_to_modify)}")
+    print(f"Fetching releases from {REPO}...")
+    all_versions = fetch_versions()
+    print(f"Found {len(all_versions)} releases.")
+
+    if args.versions:
+        selected_versions = parse_versions(args.versions, current=current, all_versions=all_versions)
+        unknown = set(selected_versions) - set(all_versions)
+        if unknown:
+            raise SystemExit(f"selected versions are not TidesDB releases: {', '.join(sorted(unknown))}")
+        print("Surveying crates.io source crates...")
+        crates_state = fetch_crates_state(selected_versions)
+        default_version = args.default_version or (
+            feature_to_version(current_default)
+            if current_default and feature_to_version(current_default) in selected_versions
+            else selected_versions[-1]
+        )
+        if default_version not in selected_versions:
+            raise SystemExit("--default-version must be one of --versions")
+        needed = [version for version in selected_versions if crates_state[version].needs_publish]
+        missing = [version for version in selected_versions if crates_state[version].status == "missing"]
+        if args.skip_publish:
+            publish_versions = []
+        elif args.publish_versions is None:
+            publish_versions = needed
+        else:
+            publish_versions = parse_publish_versions(
+                args.publish_versions,
+                selected_versions,
+                needed,
+                missing,
+            )
+    else:
+        print("Surveying crates.io source crates...")
+        crates_state = fetch_crates_state(all_versions)
+        selected_versions, default_version, publish_versions = choose_interactively(
+            all_versions,
+            current,
+            current_default,
+            crates_state,
+        )
+        if args.skip_publish:
+            publish_versions = []
+        elif args.publish_versions is not None:
+            needed = [version for version in selected_versions if crates_state[version].needs_publish]
+            missing = [version for version in selected_versions if crates_state[version].status == "missing"]
+            publish_versions = parse_publish_versions(
+                args.publish_versions,
+                selected_versions,
+                needed,
+                missing,
+            )
+
+    files_to_modify = []
+    if not args.source_crates_only:
+        files_to_modify = files_to_modify_for_plan(
+            cargo,
+            selected_versions,
+            default_version,
+            crates_state,
+        )
+
+    summarize(
+        selected_versions,
+        default_version,
+        existing_features,
+        crates_state,
+        publish_versions,
+        files_to_modify,
+        args.publish and not args.publish_dry_run,
+        args.source_crates_only,
+    )
+
+    blocking_versions = [
+        version for version in selected_versions if crates_state[version].is_blocking
+    ]
+    if blocking_versions:
+        print("\nCannot continue while source crate state is unknown:")
+        for version in blocking_versions:
+            state = crates_state[version]
+            print(f"  {source_crate_name(version)}: {'; '.join(state.reasons)}")
+        raise SystemExit(1)
 
     if args.dry_run:
-        print("\n--dry-run: no files modified.")
+        print("\n--dry-run: no files modified and no crates published.")
         return
 
-    # Update Cargo.toml
-    features = cargo.setdefault("features", {})
+    if not args.yes:
+        confirmed = inquirer.confirm(message="Apply this plan?", default=False).execute()
+        if not confirmed:
+            print("Aborted.")
+            return
 
-    # Remove old version features
-    for key in list(features.keys()):
-        if re.match(r"^v\d+_\d+_\d+$", key):
-            del features[key]
-
-    # Update default
-    new_default = [f for f in features.get("default", [])
-                   if not re.match(r"^v\d+_\d+_\d+$", f)]
-    new_default.append(default_feature)
-    features["default"] = new_default
-
-    # Add selected version features (sorted)
-    for feature in selected_features:
-        features[feature] = []
-
-    save_cargo_toml(cargo)
-
-    if default_changed:
-        update_build_rs_default(default_version)
+    if not args.source_crates_only:
+        update_cargo_toml(cargo, selected_versions, default_version, crates_state)
+        save_cargo_toml(cargo)
+        update_build_rs(selected_versions, default_version)
         update_ci_default(default_version)
+
+    if not publish_versions:
+        print("Done.")
+        return
+
+    if args.work_dir:
+        work_root = args.work_dir
+        work_root.mkdir(parents=True, exist_ok=True)
+        cleanup = False
+    else:
+        tempdir = tempfile.TemporaryDirectory(prefix="tidesdb-src-crates-")
+        work_root = Path(tempdir.name)
+        cleanup = not args.keep_work_dir
+
+    try:
+        for version in publish_versions:
+            state = crates_state[version]
+            crate_dir = write_source_crate(version, state.publish_version, work_root)
+            publish = args.publish and not args.publish_dry_run
+            action = "Publishing" if publish else "Checking"
+            print(f"{action} {source_crate_name(version)}@{state.publish_version} from {crate_dir}...", flush=True)
+            cargo_publish(crate_dir, dry_run=not publish)
+    finally:
+        if cleanup and "tempdir" in locals():
+            tempdir.cleanup()
+        else:
+            print(f"Kept prepared crates in {work_root}")
 
     print("Done.")
 


### PR DESCRIPTION
## Summary

- replace build-time GitHub release downloads with optional `tidesdb-src-vX-Y-Z` source archive crates
- extend `scripts/sync-versions.py` to survey crates.io state, prepare source crates, dry-run checks, and require explicit upload
- generate CI-only local source crate patches so PRs can test unpublished source crates
- disable optional compression codecs for source-built TidesDB v9.3.4+ so default source builds no longer need zstd/lz4/snappy installed
- bump the Rust crate to `0.10.0` and ignore Python cache artifacts

## Architecture

Each TidesDB C release now maps to a small source crate named after the release, for example `tidesdb-src-v9-3-5`. That crate owns the vendored upstream archive under `vendor/` and exposes a single `archive_path()` function. The main `tidesdb` crate keeps the existing version feature shape, but every `vX_Y_Z` feature now enables the matching optional build-dependency.

`build.rs` no longer reaches out to GitHub during builds. It selects the enabled source crate at compile time with a generated `cfg_if!` ladder, reads the archive path from that dependency, extracts it into `OUT_DIR`, and then continues with the existing CMake build flow. If multiple version features are enabled, the selection order matches the previous highest-version behavior.

For TidesDB v9.3.4 and newer, the source build passes `TIDESDB_WITH_SNAPPY=OFF`, `TIDESDB_WITH_LZ4=OFF`, and `TIDESDB_WITH_ZSTD=OFF`. Those upstream releases can compile with no optional compression backends, so source builds do not need those system packages unless we later add an explicit opt-in for compression-enabled vendored builds.

`scripts/sync-versions.py` is the control plane for keeping this synchronized. It fetches upstream TidesDB releases, reads the current Rust feature set, surveys crates.io for matching source crates, compares expected metadata and vendored archive size/hash, and then prints a plan. Missing crates are prepared at `0.1.0`; changed crates get a patch bump. Publishing remains explicit via `--publish`; normal non-dry-run flows only run `cargo publish --dry-run` for prepared source crates.

The script still updates the root `Cargo.toml`, generated `build.rs` archive selector, and CI default when requested, so version feature sync and source crate publishing are not separate workflows.

For PR CI, the same script has a local patch mode. CI prepares path crates for every current `tidesdb-src-*` dependency and writes a temporary `.cargo/config.toml` with `[patch.crates-io]` entries. Cargo can then resolve the optional source dependencies even before those crates are published. By default, the local patch mode only downloads the default version archive, so CI does not multiply GitHub archive downloads across every historical version just to satisfy dependency resolution.

## Why

The current build downloads TidesDB C release archives from GitHub inside `build.rs`. That makes ordinary Cargo builds depend on network access, GitHub availability, API/rate-limit behavior, and whatever local environment happens to be running the build script. Moving the archives into crates.io source crates makes the C source a normal Cargo dependency instead.

That gives downstream users no-network builds once Cargo has resolved and fetched dependencies, which matters for CI caches, offline builds, sandboxed package builds, and reproducible release pipelines. It also puts archive integrity under Cargo's package checksum model instead of ad hoc build-script downloading.

This should also improve incremental build behavior. Cargo can cache the source archive crate like any other dependency, and `build.rs` no longer has to perform network work or manage downloaded tarballs itself. Version changes become dependency graph changes, while rebuilding the same selected TidesDB version can reuse Cargo's existing cache path.

The source crates also give us a place to ship hotfixes to archive packaging metadata without changing the main binding crate or requiring users to hit GitHub during their build. The main crate pins to the source-crate compatibility line, and the sync script detects metadata/archive drift so updates are visible before publishing.

Disabling optional compression in the vendored source path also narrows the default native dependency surface. CI and downstream users still need the normal compiler/CMake toolchain, and objectstore builds still need curl/OpenSSL, but default source builds for current TidesDB no longer require separate codec development packages.

## Validation

- `python3 -m py_compile scripts/sync-versions.py`
- `rustfmt --check build.rs`
- `git diff --check`
- `./scripts/sync-versions.py --prepare-local-patches /private/tmp/tidesdb-local-patches --write-cargo-patch-config /private/tmp/tidesdb-cargo-home/config.toml --versions current --yes`
- `CARGO_HOME=/private/tmp/tidesdb-cargo-home cargo metadata --format-version=1`
- `CARGO_HOME=/private/tmp/tidesdb-cargo-home cargo check`
- `CARGO_HOME=/private/tmp/tidesdb-cargo-home cargo test --lib -- --test-threads=1`
- verified active v9.3.5 CMake cache has `TIDESDB_WITH_SNAPPY`, `TIDESDB_WITH_LZ4`, and `TIDESDB_WITH_ZSTD` set to `OFF`
- `./scripts/sync-versions.py --dry-run --source-crates-only --versions 9.3.5 --default-version 9.3.5 --publish-versions selected --yes`
- `./scripts/sync-versions.py --dry-run --versions all --default-version 9.3.5 --publish-versions none --yes`
- `cargo check --no-default-features --features v9_2_0,v9_3_5` with local source crate patches
