### PR TITLE
Gate source-build compression codecs

### DIFF
--- a/.github/workflows/build_from_source.yml
+++ b/.github/workflows/build_from_source.yml
@@ -149,6 +149,103 @@ jobs:
           export PATH="/mingw64/bin:$PATH"
           cargo build --release
 
+  build-from-source-no-compression:
+    runs-on: ubuntu-latest
+    name: Linux x64 (no compression)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare local source crate patches
+        shell: bash
+        run: |
+          PYTHON=python3
+          if ! command -v python3 >/dev/null 2>&1; then
+            PYTHON=python
+          fi
+          "$PYTHON" -m venv .cargo/sync-venv
+          VENV_PYTHON=.cargo/sync-venv/bin/python
+          if [ ! -x "$VENV_PYTHON" ]; then
+            VENV_PYTHON=.cargo/sync-venv/Scripts/python.exe
+          fi
+          "$VENV_PYTHON" -m pip install tomlkit requests InquirerPy
+          "$VENV_PYTHON" scripts/sync-versions.py \
+            --prepare-local-patches .cargo/tidesdb-src \
+            --write-cargo-patch-config .cargo/config.toml \
+            --versions current \
+            --yes
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential cmake pkg-config
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.0
+
+      - name: Build from source without compression
+        run: cargo build --release --no-default-features --features v9_3_6
+
+  build-from-source-compression-gates:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: compression
+            features: v9_3_6,compression
+            packages: libzstd-dev liblz4-dev libsnappy-dev
+          - name: snappy
+            features: v9_3_6,snappy
+            packages: libsnappy-dev
+          - name: lz4
+            features: v9_3_6,lz4
+            packages: liblz4-dev
+          - name: zstd
+            features: v9_3_6,zstd
+            packages: libzstd-dev
+
+    runs-on: ubuntu-latest
+    name: Linux x64 (${{ matrix.name }} compression gate)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare local source crate patches
+        shell: bash
+        run: |
+          PYTHON=python3
+          if ! command -v python3 >/dev/null 2>&1; then
+            PYTHON=python
+          fi
+          "$PYTHON" -m venv .cargo/sync-venv
+          VENV_PYTHON=.cargo/sync-venv/bin/python
+          if [ ! -x "$VENV_PYTHON" ]; then
+            VENV_PYTHON=.cargo/sync-venv/Scripts/python.exe
+          fi
+          "$VENV_PYTHON" -m pip install tomlkit requests InquirerPy
+          "$VENV_PYTHON" scripts/sync-versions.py \
+            --prepare-local-patches .cargo/tidesdb-src \
+            --write-cargo-patch-config .cargo/config.toml \
+            --versions current \
+            --yes
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential cmake pkg-config ${{ matrix.packages }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.0
+
+      - name: Build source compression gate
+        run: cargo build --release --no-default-features --features ${{ matrix.features }}
+
   build-from-source-objectstore:
     strategy:
       fail-fast: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,11 @@ tidesdb-src-v9-3-6 = {version = "0.1", optional = true}
 tempfile = "3.10"
 
 [features]
-default = ["v9_3_6"]
+default = ["v9_3_6", "compression"]
+compression = ["snappy", "lz4", "zstd"]
+snappy = []
+lz4 = []
+zstd = []
 objectstore = []
 v9_3_6 = ["dep:tidesdb-src-v9-3-6"]
 

--- a/build.rs
+++ b/build.rs
@@ -85,6 +85,18 @@ fn with_objectstore() -> bool {
     std::env::var("CARGO_FEATURE_OBJECTSTORE").is_ok()
 }
 
+fn with_snappy() -> bool {
+    std::env::var("CARGO_FEATURE_SNAPPY").is_ok()
+}
+
+fn with_lz4() -> bool {
+    std::env::var("CARGO_FEATURE_LZ4").is_ok()
+}
+
+fn with_zstd() -> bool {
+    std::env::var("CARGO_FEATURE_ZSTD").is_ok()
+}
+
 fn build_from_source(version: &str) -> PathBuf {
     let out_dir = std::env::var("OUT_DIR").unwrap();
     let src_dir = extract_archive(version, &out_dir);
@@ -92,6 +104,15 @@ fn build_from_source(version: &str) -> PathBuf {
     let mut cfg = cmake::Config::new(&src_dir);
     cfg.define("TIDESDB_BUILD_TESTS", "OFF")
         .define("BUILD_SHARED_LIBS", "OFF");
+
+    if version_at_least(version, 9, 3, 4) {
+        cfg.define(
+            "TIDESDB_WITH_SNAPPY",
+            if with_snappy() { "ON" } else { "OFF" },
+        )
+        .define("TIDESDB_WITH_LZ4", if with_lz4() { "ON" } else { "OFF" })
+        .define("TIDESDB_WITH_ZSTD", if with_zstd() { "ON" } else { "OFF" });
+    }
 
     if with_objectstore() {
         cfg.define("TIDESDB_WITH_S3", "ON");
@@ -172,13 +193,25 @@ fn main() {
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
     println!("cargo:rustc-link-lib=static=tidesdb");
 
-    // Link compression dependencies via pkg-config (handles search paths)
     let mut missing = Vec::new();
-    for dep in &["libzstd", "liblz4", "snappy"] {
-        if pkg_config::probe_library(dep).is_err() {
-            let lib_name = dep.strip_prefix("lib").unwrap_or(dep);
-            println!("cargo:rustc-link-lib={lib_name}");
-            missing.push(lib_name);
+    let compression_deps = [
+        ("libzstd", "zstd", with_zstd()),
+        ("liblz4", "lz4", with_lz4()),
+        ("snappy", "snappy", with_snappy()),
+    ];
+    let always_needs_compression_deps = !version_at_least(&version, 9, 3, 4);
+
+    if always_needs_compression_deps || compression_deps.iter().any(|(_, _, enabled)| *enabled) {
+        // Older TidesDB releases always compile compression backends into the C
+        // library. v9.3.4+ can gate each optional codec independently.
+        for (dep, lib_name, enabled) in compression_deps {
+            if !always_needs_compression_deps && !enabled {
+                continue;
+            }
+            if pkg_config::probe_library(dep).is_err() {
+                println!("cargo:rustc-link-lib={lib_name}");
+                missing.push(lib_name);
+            }
         }
     }
     // Link S3/object store dependencies (libcurl + openssl)
@@ -197,20 +230,50 @@ fn main() {
     if !missing.is_empty() {
         let mut msg = format!(
             "cargo:warning=Could not find {} via pkg-config, falling back to link by name. \
-             If linking fails, install them:\n\
-             \x20 Debian/Ubuntu: sudo apt install libzstd-dev liblz4-dev libsnappy-dev",
+             If linking fails, install them:",
             missing.join(", ")
         );
-        if with_objectstore() {
-            msg.push_str(" libcurl4-openssl-dev libssl-dev");
+        let needs_compression_deps =
+            always_needs_compression_deps || with_snappy() || with_lz4() || with_zstd();
+
+        let mut debian_packages = Vec::new();
+        let mut macos_packages = Vec::new();
+        let mut windows_packages = Vec::new();
+
+        if always_needs_compression_deps || with_zstd() {
+            debian_packages.push("libzstd-dev");
+            macos_packages.push("zstd");
+            windows_packages.push("zstd:x64-windows");
         }
-        msg.push_str("\n\x20 macOS:         brew install zstd lz4 snappy");
-        if with_objectstore() {
-            msg.push_str(" curl openssl");
+        if always_needs_compression_deps || with_lz4() {
+            debian_packages.push("liblz4-dev");
+            macos_packages.push("lz4");
+            windows_packages.push("lz4:x64-windows");
         }
-        msg.push_str("\n\x20 Windows:       vcpkg install zstd:x64-windows lz4:x64-windows snappy:x64-windows");
+        if always_needs_compression_deps || with_snappy() {
+            debian_packages.push("libsnappy-dev");
+            macos_packages.push("snappy");
+            windows_packages.push("snappy:x64-windows");
+        }
         if with_objectstore() {
-            msg.push_str(" curl:x64-windows openssl:x64-windows");
+            debian_packages.extend(["libcurl4-openssl-dev", "libssl-dev"]);
+            macos_packages.extend(["curl", "openssl"]);
+            windows_packages.extend(["curl:x64-windows", "openssl:x64-windows"]);
+        }
+
+        if needs_compression_deps || with_objectstore() {
+            msg.push_str(&format!(
+                "\n\x20 Debian/Ubuntu: sudo apt install {}",
+                debian_packages.join(" ")
+            ));
+            msg.push_str(&format!(
+                "\n\x20 macOS:         brew install {}",
+                macos_packages.join(" ")
+            ));
+            msg.push_str(&format!(
+                "\n\x20 Windows:       vcpkg install {}",
+                windows_packages.join(" ")
+            ));
         }
         println!("{msg}");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,7 +422,7 @@ mod tests {
             .write_buffer_size(128 * 1024 * 1024)
             .level_size_ratio(10)
             .min_levels(5)
-            .compression_algorithm(CompressionAlgorithm::Lz4)
+            .compression_algorithm(CompressionAlgorithm::None)
             .enable_bloom_filter(true)
             .bloom_fpr(0.01)
             .enable_block_indexes(true)
@@ -552,7 +552,7 @@ mod tests {
         // Create new configuration
         let new_config = ColumnFamilyConfig::new()
             .write_buffer_size(256 * 1024 * 1024)
-            .compression_algorithm(CompressionAlgorithm::Zstd);
+            .compression_algorithm(CompressionAlgorithm::None);
 
         // Update runtime config
         cf.update_runtime_config(&new_config, false).unwrap();
@@ -621,6 +621,7 @@ mod tests {
         assert_eq!(config.min_levels, 4);
         assert_eq!(config.dividing_level_offset, 2);
         assert_eq!(config.klog_value_threshold, 1024);
+        assert_eq!(config.compression_algorithm, CompressionAlgorithm::Lz4);
         assert_eq!(config.index_sample_ratio, 16);
         assert_eq!(config.block_index_prefix_len, 4);
         assert_eq!(config.comparator_name, "memcmp");
@@ -638,7 +639,7 @@ mod tests {
         // Create column family with B+tree format enabled
         let cf_config = ColumnFamilyConfig::new()
             .use_btree(true)
-            .compression_algorithm(CompressionAlgorithm::Lz4);
+            .compression_algorithm(CompressionAlgorithm::None);
 
         db.create_column_family("btree_cf", cf_config).unwrap();
 


### PR DESCRIPTION
## Summary

This keeps source-build compression enabled by default, but makes it configurable for TidesDB versions that support optional codec backends.

- add a default-on `compression` Cargo feature
- add granular `snappy`, `lz4`, and `zstd` Cargo features
- map those features to TidesDB CMake options for `v9.3.4+`
- keep older TidesDB versions on the existing behavior, because those versions always compile compression backends into the C library
- add CI coverage for a source build with all compression codecs disabled
- add CI coverage for the aggregate `compression` feature and each individual codec gate

## Feature Model

Default behavior is unchanged for ordinary users:

```toml
default = ["v9_3_6", "compression"]
compression = ["snappy", "lz4", "zstd"]
snappy = []
lz4 = []
zstd = []
```

That means `cargo build` still builds the vendored TidesDB source with snappy, lz4, and zstd enabled, and still expects the corresponding native development packages to be available.

Users who want a lean source build can now opt out:

```sh
cargo build --no-default-features --features v9_3_6
```

Users can also enable only selected codecs:

```sh
cargo build --no-default-features --features v9_3_6,zstd
cargo build --no-default-features --features v9_3_6,lz4,snappy
```

For `v9.3.4+`, `build.rs` now passes the matching CMake switches:

- `TIDESDB_WITH_SNAPPY=ON|OFF`
- `TIDESDB_WITH_LZ4=ON|OFF`
- `TIDESDB_WITH_ZSTD=ON|OFF`

For older TidesDB versions, the build script keeps linking all compression dependencies because those releases do not expose the optional codec CMake switches.

## Why

TidesDB upstream can compile without compression libraries starting around the `v9.3.4` line. Instead of removing compression from `tidesdb-src` builds, this PR makes compression an explicit part of the Cargo feature surface.

That gives us both behaviors:

- compatibility-first default builds with all compression codecs enabled
- smaller no-compression source builds for constrained CI, sandboxed packaging, or users who only need `CompressionAlgorithm::None`

## CI

The existing source-build matrix remains compression-enabled and installs zstd/lz4/snappy as before.

This PR adds a separate Linux source-build job that intentionally does not install compression development packages and builds with:

```sh
cargo build --release --no-default-features --features v9_3_6
```

That job verifies the opt-out path without weakening default CI coverage.

It also adds a Linux compression-gate matrix that builds:

- `v9_3_6,compression`
- `v9_3_6,snappy`
- `v9_3_6,lz4`
- `v9_3_6,zstd`

Each matrix entry installs only the native package(s) required by that feature selection. This checks that the umbrella feature and each sub-gate independently drive the expected CMake/link path.

## Validation

- `git diff --check`
- `rustfmt --check build.rs`
- `CARGO_HOME=/private/tmp/tidesdb-cargo-home CARGO_TARGET_DIR=/private/tmp/tidesdb-target-compression cargo test --lib -- --test-threads=1`
- `CARGO_HOME=/private/tmp/tidesdb-cargo-home CARGO_TARGET_DIR=/private/tmp/tidesdb-target-no-compression cargo test --lib --no-default-features --features v9_3_6 -- --test-threads=1`
- `CARGO_HOME=/private/tmp/tidesdb-cargo-home CARGO_TARGET_DIR=/private/tmp/tidesdb-target-gate-compression cargo build --no-default-features --features v9_3_6,compression`
- `CARGO_HOME=/private/tmp/tidesdb-cargo-home CARGO_TARGET_DIR=/private/tmp/tidesdb-target-gate-snappy cargo build --no-default-features --features v9_3_6,snappy`
- `CARGO_HOME=/private/tmp/tidesdb-cargo-home CARGO_TARGET_DIR=/private/tmp/tidesdb-target-gate-lz4 cargo build --no-default-features --features v9_3_6,lz4`
- `CARGO_HOME=/private/tmp/tidesdb-cargo-home CARGO_TARGET_DIR=/private/tmp/tidesdb-target-gate-zstd cargo build --no-default-features --features v9_3_6,zstd`
- verified default source build has `TIDESDB_WITH_SNAPPY`, `TIDESDB_WITH_LZ4`, and `TIDESDB_WITH_ZSTD` set to `ON`
- verified no-compression source build has those three CMake options set to `OFF`, with `TIDESDB_HAVE_*` macros undefined
- verified the single-codec gate builds only define their matching `TIDESDB_HAVE_*` macro
