### PR TITLE
feat: add TidesDB 9.3.15 source feature

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Checkout tidesdb-rs repo
         uses: actions/checkout@v4
         with:
-          repository: tidesdb/tidesdb-rs
           path: tidesdb-rs
 
       - name: Prepare local source crate patches
@@ -56,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: tidesdb/tidesdb
-          ref: v9.3.6
+          ref: v9.3.15
           path: tidesdb
 
       - name: Install dependencies (Linux)

--- a/.github/workflows/build_from_source.yml
+++ b/.github/workflows/build_from_source.yml
@@ -173,6 +173,7 @@ jobs:
           "$VENV_PYTHON" scripts/sync-versions.py \
             --prepare-local-patches .cargo/tidesdb-src \
             --write-cargo-patch-config .cargo/config.toml \
+            --local-patch-archive-versions all \
             --versions current \
             --yes
 
@@ -187,6 +188,9 @@ jobs:
           toolchain: 1.85.0
 
       - name: Build from source without compression
+        run: cargo build --release --no-default-features --features v9_3_15
+
+      - name: Build retained source version without compression
         run: cargo build --release --no-default-features --features v9_3_6
 
   build-from-source-compression-gates:
@@ -195,16 +199,16 @@ jobs:
       matrix:
         include:
           - name: compression
-            features: v9_3_6,compression
+            features: v9_3_15,compression
             packages: libzstd-dev liblz4-dev libsnappy-dev
           - name: snappy
-            features: v9_3_6,snappy
+            features: v9_3_15,snappy
             packages: libsnappy-dev
           - name: lz4
-            features: v9_3_6,lz4
+            features: v9_3_15,lz4
             packages: liblz4-dev
           - name: zstd
-            features: v9_3_6,zstd
+            features: v9_3_15,zstd
             packages: libzstd-dev
 
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tidesdb"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 authors = ["TidesDB <hello@tidesdb.com>"]
 description = "TidesDB is a high-performance embeddable, durable, adaptive, and optionally cloud-native key-value storage engine"
@@ -23,18 +23,20 @@ flate2 = "1"
 tar = "0.4"
 cfg-if = "1"
 tidesdb-src-v9-3-6 = {version = "0.1", optional = true}
+tidesdb-src-v9-3-15 = {version = "0.1", optional = true}
 
 [dev-dependencies]
 tempfile = "3.10"
 
 [features]
-default = ["v9_3_6", "compression"]
+default = ["compression", "v9_3_15"]
 compression = ["snappy", "lz4", "zstd"]
 snappy = []
 lz4 = []
 zstd = []
 objectstore = []
 v9_3_6 = ["dep:tidesdb-src-v9-3-6"]
+v9_3_15 = ["dep:tidesdb-src-v9-3-15"]
 
 [lib]
 name = "tidesdb"

--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,7 @@ fn selected_version() -> String {
     }
     match selected {
         Some((a, b, c)) => format!("{a}.{b}.{c}"),
-        None => "9.3.6".to_string(),
+        None => "9.3.15".to_string(),
     }
 }
 
@@ -42,7 +42,12 @@ fn version_at_least(version: &str, major: u32, minor: u32, patch: u32) -> bool {
 
 // BEGIN GENERATED TIDESDB SOURCE ARCHIVES
 cfg_if::cfg_if! {
-    if #[cfg(feature = "v9_3_6")] {
+    if #[cfg(feature = "v9_3_15")] {
+        fn source_archive() -> PathBuf {
+            tidesdb_src_v9_3_15::archive_path()
+        }
+    }
+    else if #[cfg(feature = "v9_3_6")] {
         fn source_archive() -> PathBuf {
             tidesdb_src_v9_3_6::archive_path()
         }


### PR DESCRIPTION
## Summary

- add an additive `v9_3_15` Cargo feature backed by `tidesdb-src-v9-3-15`
- make TidesDB 9.3.15 the default vendored native version and bump the wrapper to 0.11.2
- retain `v9_3_6` and keep a minimal no-compression smoke build for it
- move native and codec CI lanes to v9.3.15
- make the main pull-request workflow test the pull-request revision instead of checking out upstream `master`

TidesDB v9.3.15 contains the incomplete transaction-batch rejection fix from tidesdb/tidesdb#664. That native change does not alter the public C API, so no speculative Rust FFI or transaction API changes are needed.

## Publication prerequisite

`tidesdb-src-v9-3-15@0.1.0` is not yet on crates.io. This PR is intentionally a draft and must not be merged or released until a TidesDB maintainer publishes that source crate. The repository script can prepare and publish it with:

```sh
uv run scripts/sync-versions.py \
  --versions 9.3.15 \
  --source-crates-only \
  --publish \
  --yes
```

CI prepares local source-crate patches, so it can validate this branch before registry publication.

## Validation

- `cargo publish --dry-run` for generated `tidesdb-src-v9-3-15@0.1.0`
- WSL/Linux: `cargo test --no-default-features --features v9_3_15`
  - 71 unit tests passed
  - 5 doctests passed
- Windows/MSVC: `cargo check --all-targets --no-default-features --features v9_3_15`
- Windows/MSVC: `cargo check --all-targets --no-default-features --features v9_3_6`
- official sync-script dry run reports both version features current and only the source crate missing
- `rustfmt --edition 2024 --check build.rs`
- `git diff --check`
- workflow YAML parse check

## Known native release metadata issue

The v9.3.15 archive contains the transaction fix, but its CMake project version still reports 9.3.14. That affects exact system-library discovery, not the vendored-source build covered here: tidesdb/tidesdb#665.